### PR TITLE
Prevenir que se corten los articles al imprimir

### DIFF
--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -103,5 +103,9 @@ const { image, summary } = basics
     astro-dev-toolbar {
       display: none !important;
     }
+
+    article {
+      break-inside: avoid;
+    }
   }
 </style>


### PR DESCRIPTION
Antes:

![image](https://github.com/midudev/minimalist-portfolio-json/assets/69643444/f2aa7908-3c7b-4bde-9900-e6cb523e84bb)

Después:

![image](https://github.com/midudev/minimalist-portfolio-json/assets/69643444/406411f6-3622-4dcd-9b95-0ad22c47498b)
