### PR TITLE
¡Cambié la URL porque la antigua estaba más perdida que Waldo!

### DIFF
--- a/cv.json
+++ b/cv.json
@@ -228,7 +228,7 @@
         "Multidioma",
         "JavaScript & TypeScript"
       ],
-      "url": "https://advent.js/dev"
+      "url": "https://adventjs.dev"
     },
     {
       "name": "Codember",


### PR DESCRIPTION
¡Hola, midudev! Este cambio es tan pequeño que hasta Waldo lo habría encontrado antes. Solo actualicé la URL del Adventjs para que todos puedan llegar a destino sin perderse en el ciberespacio.
 
Puede que esta sea la actualización más sencilla de la historia de los pull requests. Solo una URL extraviada que encontró su camino de regreso a casa.

## Pasos de Verificación:
- [x] Confirmar que la URL anterior estaba más perdida que Waldo.
- [x] Asegurarse de que la nueva URL no necesite un mapa para ser encontrada.
- [x] Comprobar que la nueva URL aún conduce al tesoro (o recurso) correcto.