### PR TITLE
Replace NinjaKeys with vanilla alternative

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   "dependencies": {
     "@astrojs/check": "0.4.1",
     "astro": "4.3.2",
-    "ninja-keys": "1.2.2",
+    "hotkeypad": "0.1.0",
     "typescript": "5.3.3"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,9 +11,9 @@ dependencies:
   astro:
     specifier: 4.3.2
     version: 4.3.2(typescript@5.3.3)
-  ninja-keys:
-    specifier: 1.2.2
-    version: 1.2.2
+  hotkeypad:
+    specifier: 0.1.0
+    version: 0.1.0
   typescript:
     specifier: 5.3.3
     version: 5.3.3
@@ -610,23 +610,6 @@ packages:
       '@jridgewell/sourcemap-codec': 1.4.15
     dev: false
 
-  /@lit-labs/ssr-dom-shim@1.1.2:
-    resolution: {integrity: sha512-jnOD+/+dSrfTWYfSXBXlo5l5f0q1UuJo3tkbMDCYA2lKUYq79jaxqtGEvnRoh049nt1vdo1+45RinipU6FGY2g==}
-    dev: false
-
-  /@lit/reactive-element@1.6.3:
-    resolution: {integrity: sha512-QuTgnG52Poic7uM1AN5yJ09QMe0O28e10XzSvWDz02TJiiKee4stsiownEIadWm8nYzyDAyT+gKzUoZmiWQtsQ==}
-    dependencies:
-      '@lit-labs/ssr-dom-shim': 1.1.2
-    dev: false
-
-  /@material/mwc-icon@0.25.3:
-    resolution: {integrity: sha512-36076AWZIRSr8qYOLjuDDkxej/HA0XAosrj7TS1ZeLlUBnLUtbDtvc1S7KSa0hqez7ouzOqGaWK24yoNnTa2OA==}
-    dependencies:
-      lit: 2.2.6
-      tslib: 2.6.2
-    dev: false
-
   /@nodelib/fs.scandir@2.1.5:
     resolution: {integrity: sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==}
     engines: {node: '>= 8'}
@@ -811,10 +794,6 @@ packages:
     resolution: {integrity: sha512-ABoYdNQ/kBSsLvZAekMhIPMQ3YUZvavStpKYs7BjLLuKVmIMA0LUgZ7b54zzuWJRbHF80v1cNf4r90Vd6eMQDg==}
     dependencies:
       '@types/unist': 2.0.10
-    dev: false
-
-  /@types/trusted-types@2.0.7:
-    resolution: {integrity: sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==}
     dev: false
 
   /@types/unist@2.0.10:
@@ -1799,8 +1778,8 @@ packages:
       space-separated-tokens: 2.0.2
     dev: false
 
-  /hotkeys-js@3.8.7:
-    resolution: {integrity: sha512-ckAx3EkUr5XjDwjEHDorHxRO2Kb7z6Z2Sxul4MbBkN8Nho7XDslQsgMJT+CiJ5Z4TgRxxvKHEpuLE3imzqy4Lg==}
+  /hotkeypad@0.1.0:
+    resolution: {integrity: sha512-e9R4mp2B0YtjV7Rm9KpMMyMSMwvEjb1gHxnvpnMQD0ussSOobl6+Tr6rFCq2aNLgExkcfHtShyd/DQqM4qqHTw==}
     dev: false
 
   /html-escaper@3.0.3:
@@ -1989,28 +1968,6 @@ packages:
   /kleur@4.1.5:
     resolution: {integrity: sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ==}
     engines: {node: '>=6'}
-    dev: false
-
-  /lit-element@3.3.3:
-    resolution: {integrity: sha512-XbeRxmTHubXENkV4h8RIPyr8lXc+Ff28rkcQzw3G6up2xg5E8Zu1IgOWIwBLEQsu3cOVFqdYwiVi0hv0SlpqUA==}
-    dependencies:
-      '@lit-labs/ssr-dom-shim': 1.1.2
-      '@lit/reactive-element': 1.6.3
-      lit-html: 2.8.0
-    dev: false
-
-  /lit-html@2.8.0:
-    resolution: {integrity: sha512-o9t+MQM3P4y7M7yNzqAyjp7z+mQGa4NS4CxiyLqFPyFWyc4O+nodLrkrxSaCTrla6M5YOLaT3RpbbqjszB5g3Q==}
-    dependencies:
-      '@types/trusted-types': 2.0.7
-    dev: false
-
-  /lit@2.2.6:
-    resolution: {integrity: sha512-K2vkeGABfSJSfkhqHy86ujchJs3NR9nW1bEEiV+bXDkbiQ60Tv5GUausYN2mXigZn8lC1qXuc46ArQRKYmumZw==}
-    dependencies:
-      '@lit/reactive-element': 1.6.3
-      lit-element: 3.3.3
-      lit-html: 2.8.0
     dev: false
 
   /load-yaml-file@0.2.0:
@@ -2558,14 +2515,6 @@ packages:
       sax: 1.3.0
     transitivePeerDependencies:
       - supports-color
-    dev: false
-
-  /ninja-keys@1.2.2:
-    resolution: {integrity: sha512-ylo8jzKowi3XBHkgHRjBJaKQkl32WRLr7kRiA0ajiku11vHRDJ2xANtTScR5C7XlDwKEOYvUPesCKacUeeLAYw==}
-    dependencies:
-      '@material/mwc-icon': 0.25.3
-      hotkeys-js: 3.8.7
-      lit: 2.2.6
     dev: false
 
   /nlcst-to-string@3.1.1:
@@ -3371,10 +3320,6 @@ packages:
         optional: true
     dependencies:
       typescript: 5.3.3
-    dev: false
-
-  /tslib@2.6.2:
-    resolution: {integrity: sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==}
     dev: false
 
   /tunnel-agent@0.6.0:

--- a/src/components/KeyboardManager.astro
+++ b/src/components/KeyboardManager.astro
@@ -1,4 +1,6 @@
 ---
+import 'hotkeypad/reset.css'
+import 'hotkeypad/index.css'
 import { type SocialIcon } from "@/types"
 import { basics } from "@cv"
 
@@ -38,7 +40,7 @@ const SOCIAL_ICONS: SocialIcon = {
     d="M18.901 1.153h3.68l-8.04 9.19L24 22.846h-7.406l-5.8-7.584-6.638 7.584H.474l8.6-9.83L0 1.154h7.594l5.243 6.932ZM17.61 20.644h2.039L6.486 3.24H4.298Z"
   ></path></svg
 >
-`,
+`
 }
 
 const profilesInfo = profiles.map(({ network, url }) => {
@@ -51,7 +53,7 @@ const profilesInfo = profiles.map(({ network, url }) => {
     title: `Visitar ${network}`,
     url,
     icon,
-    hotkey: `ctrl+${firstLetter}`,
+    hotkey: `ctrl+${firstLetter}`
   }
 })
 ---
@@ -80,14 +82,14 @@ const profilesInfo = profiles.map(({ network, url }) => {
   </svg>
 </div>
 
-<ninja-keys
+<div
+  id="hotkeypad"
+  data-placeholder="Buscar comando"
   data-info={JSON.stringify(profilesInfo)}
-  placeholder="Buscar comando"
-  hideBreadcrumbs></ninja-keys>
+>
+</div>
 
 <script>
-  import "ninja-keys"
-
   interface Info {
     id: string
     section: string
@@ -95,16 +97,46 @@ const profilesInfo = profiles.map(({ network, url }) => {
     url: string
     icon: string
     hotkey: string
-    handler?: () => void;
+    handler?: () => void
   }
 
-  interface NinjaKeysElement extends HTMLElement {
-    data: Info[]
-  }
+  import HotKeyPad from "hotkeypad"
 
-  const ninja = document.querySelector<NinjaKeysElement>("ninja-keys")!
+  const hotkeypad = new HotKeyPad()
+  const info = hotkeypad.instance.getAttribute("data-info") ?? "[]"
+  const parsedInfo = JSON.parse(info) as Info[]
+
+  const data = parsedInfo.map(
+    ({ url, hotkey, icon, id, section, title }) => {
+      return {
+        id,
+        title,
+        icon,
+        hotkey,
+        section,
+        handler: () => {
+          window.open(url, "_blank")
+        }
+      }
+    }
+  )
+  hotkeypad.setCommands([
+    {
+      id: "print",
+      title: "Imprimir",
+      icon: `<svg style="margin-right: 8px" width="16" height="16" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
+  <path stroke-linecap="round" stroke-linejoin="round" d="M6.72 13.829c-.24.03-.48.062-.72.096m.72-.096a42.415 42.415 0 0 1 10.56 0m-10.56 0L6.34 18m10.94-4.171c.24.03.48.062.72.096m-.72-.096L17.66 18m0 0 .229 2.523a1.125 1.125 0 0 1-1.12 1.227H7.231c-.662 0-1.18-.568-1.12-1.227L6.34 18m11.318 0h1.091A2.25 2.25 0 0 0 21 15.75V9.456c0-1.081-.768-2.015-1.837-2.175a48.055 48.055 0 0 0-1.913-.247M6.34 18H5.25A2.25 2.25 0 0 1 3 15.75V9.456c0-1.081.768-2.015 1.837-2.175a48.041 48.041 0 0 1 1.913-.247m10.5 0a48.536 48.536 0 0 0-10.5 0m10.5 0V3.375c0-.621-.504-1.125-1.125-1.125h-8.25c-.621 0-1.125.504-1.125 1.125v3.659M18 10.5h.008v.008H18V10.5Zm-3 0h.008v.008H15V10.5Z" />
+</svg>`,
+      hotkey: "ctrl+P",
+      section: "Acciones",
+      handler: () => {
+        window.print()
+      }
+    },
+    ...data
+  ])
+
   const footerButton = document.getElementById("footer-button")
-
   footerButton?.addEventListener("click", () => {
     var event = new KeyboardEvent("keydown", {
       key: "K",
@@ -114,56 +146,14 @@ const profilesInfo = profiles.map(({ network, url }) => {
       ctrlKey: true,
       altKey: false,
       shiftKey: false,
-      metaKey: false,
+      metaKey: false
     })
 
     document.dispatchEvent(event)
   })
-
-  if (ninja != null) {
-    const info = ninja.getAttribute("data-info") ?? "[]"
-    const parsedInfo = JSON.parse(info)
-
-    const data = parsedInfo.map(
-      ({ url, hotkey, icon, id, section, title }: Info) => {
-        return {
-          id,
-          title,
-          icon,
-          hotkey,
-          section,
-          handler: () => {
-            window.open(url, "_blank")
-          },
-        }
-      }
-    )
-
-    ninja.data = [
-      {
-        id: "print",
-        title: "Imprimir",
-        icon: `<svg style="margin-right: 8px" width="16" height="16" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
-  <path stroke-linecap="round" stroke-linejoin="round" d="M6.72 13.829c-.24.03-.48.062-.72.096m.72-.096a42.415 42.415 0 0 1 10.56 0m-10.56 0L6.34 18m10.94-4.171c.24.03.48.062.72.096m-.72-.096L17.66 18m0 0 .229 2.523a1.125 1.125 0 0 1-1.12 1.227H7.231c-.662 0-1.18-.568-1.12-1.227L6.34 18m11.318 0h1.091A2.25 2.25 0 0 0 21 15.75V9.456c0-1.081-.768-2.015-1.837-2.175a48.055 48.055 0 0 0-1.913-.247M6.34 18H5.25A2.25 2.25 0 0 1 3 15.75V9.456c0-1.081.768-2.015 1.837-2.175a48.041 48.041 0 0 1 1.913-.247m10.5 0a48.536 48.536 0 0 0-10.5 0m10.5 0V3.375c0-.621-.504-1.125-1.125-1.125h-8.25c-.621 0-1.125.504-1.125 1.125v3.659M18 10.5h.008v.008H18V10.5Zm-3 0h.008v.008H15V10.5Z" />
-</svg>`,
-        hotkey: "ctrl+P",
-        section: "Acciones",
-        handler: () => {
-          window.print()
-        },
-      },
-      ...data,
-    ]
-  }
 </script>
 
 <style>
-  @media print {
-    ninja-keys {
-      display: none !important;
-    }
-  }
-
   @keyframes fadeIn {
     from {
       opacity: 0;


### PR DESCRIPTION
Replaced ninja-keys package for HotKeyPad, which I made myself with vanilla JS and no dependencies. It looks and works the same as ninja-keys, although you have to import the reset and component styles for it to look good.

![image](https://github.com/midudev/minimalist-portfolio-json/assets/39781228/1977b8c4-7760-4c01-a47f-800d94a5ec81)