### PR TITLE
Make helper clickable

### DIFF
--- a/src/components/KeyboardManager.astro
+++ b/src/components/KeyboardManager.astro
@@ -211,6 +211,8 @@ const profilesInfo = profiles.map(({ network, url }) => {
     animation: linear 0.3s fadeIn;
     animation-timeline: --revealing;
     animation-range: entry 100% cover 10%;
+
+    user-select: none;
   }
 
   kbd {

--- a/src/components/KeyboardManager.astro
+++ b/src/components/KeyboardManager.astro
@@ -151,6 +151,9 @@ const profilesInfo = profiles.map(({ network, url }) => {
 
     document.dispatchEvent(event)
   })
+
+  const footer = document.getElementById("normal-footer")
+  footer?.addEventListener('click', ()=>hotkeypad.open())
 </script>
 
 <style>
@@ -213,6 +216,11 @@ const profilesInfo = profiles.map(({ network, url }) => {
     animation-range: entry 100% cover 10%;
 
     user-select: none;
+  }
+
+  footer:hover {
+    background: #f5f5f5;
+    cursor: pointer;
   }
 
   kbd {

--- a/src/components/KeyboardManager.astro
+++ b/src/components/KeyboardManager.astro
@@ -157,6 +157,7 @@ const profilesInfo = profiles.map(({ network, url }) => {
   @keyframes fadeIn {
     from {
       opacity: 0;
+      pointer-events: none;
     }
     to {
       opacity: 1;


### PR DESCRIPTION
Enhanced the accessibility of the access key helper by adding click functionality. Users can now click on the helper to open the command palette in addition to using the keyboard shortcut Cmd + K.

![Capt_OPT](https://github.com/midudev/minimalist-portfolio-json/assets/74639893/f13fa3da-55e5-4290-b99d-c24ba586dff6)

Additionally implemented a fix to prevent the content behind it from being no selectable when the helper is hidden. Previously, the hidden helper would block the selection of content behind it.